### PR TITLE
Fix crash when MCP tool calls fail in github_agent.py

### DIFF
--- a/python/m1/gh_auth/github_agent.py
+++ b/python/m1/gh_auth/github_agent.py
@@ -162,6 +162,21 @@ async def main() -> None:
 
     async with client.session("github") as session:
         tools = await load_mcp_tools(session)
+        for tool in tools:
+            # BaseTool.handle_tool_error only catches ToolException, not the MCP
+            # server's own errors (e.g. McpError on a 404), which would otherwise
+            # crash the whole run. Wrap the coroutine so failures become a normal
+            # tool result the agent can see and react to.
+            def _make_safe(coro):
+                async def _safe(*args, **kwargs):
+                    try:
+                        return await coro(*args, **kwargs)
+                    except Exception as e:  # noqa: BLE001
+                        # response_format="content_and_artifact" expects a 2-tuple
+                        return f"Tool call failed: {e}", None
+                return _safe
+
+            tool.coroutine = _make_safe(tool.coroutine)
         print(f"github: {len(tools)} tool(s) available")
 
         agent = create_deep_agent(model=model, tools=tools)


### PR DESCRIPTION
GitHub MCP tool calls can fail with a real error from the server (e.g. a 404 when the agent probes a repository that doesn't exist — which is easy to trigger, since models often guess at a profile-README repo named after the username). Right now that exception propagates uncaught and crashes the whole `asyncio.run(main())`, instead of letting the agent see the failure and continue.

This wraps each loaded MCP tool's coroutine to catch failures and return them as a normal `(content, artifact)` tool result — LangGraph's `ToolNode`/`BaseTool.handle_tool_error` only catch `ToolInvocationError`/`ToolException`, not arbitrary exceptions like MCP's `McpError`, so this can't be fixed via the built-in flag.

Tested locally: reproduced the crash (repo lookup returning 404), applied the fix, confirmed the agent now completes and answers the original question instead of crashing.