### PR TITLE
fix(python): define azure/bedrock/google extras documented in models.py

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,6 +32,21 @@ dependencies = [
     "questionary>=2.0.0",
 ]
 
+# Provider extras referenced by the install table in models.py
+# (`uv sync --extra azure|bedrock|google`).
+[project.optional-dependencies]
+# AzureChatOpenAI ships with langchain-openai (already a core dependency);
+# defining the extra keeps the documented command valid.
+azure = [
+    "langchain-openai",
+]
+bedrock = [
+    "langchain-aws",
+]
+google = [
+    "langchain-google-genai",
+]
+
 [tool.ruff]
 lint.select = ["E", "F", "I", "UP"]
 lint.ignore = ["T201", "E501", "UP006", "UP007", "E402"]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -246,6 +246,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/30/96cf7d324e75cd2c349e2911ae2334d987fb8525d551495a2ef6758c26f3/boto3-1.43.83.tar.gz", hash = "sha256:6413d6e99f716af5d333a732db140e4b3359cac005a1271b11777b6d9ca82194", size = 112686, upload-time = "2026-08-28T19:35:52.273Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/4b/843f30dc77324778efa90c4169d503963668760b8d8abdf26a61bd090141/boto3-1.43.83-py3-none-any.whl", hash = "sha256:73a3564f737d4516625964eee709a498fa98ccee6aca929febad2b0b5fbeae1e", size = 140025, upload-time = "2026-08-28T19:35:49.228Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/6f/cf16418004c832e6eb9abc6905fa323a3bf96a76ca7f2e97858801a4103e/botocore-1.43.83.tar.gz", hash = "sha256:d9389b3b74400c34219965a2fb858c1d48744718865ee0496fd03bd5b21b943f", size = 16010078, upload-time = "2026-08-28T19:35:46.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/50/332d6713fa09b05ff0882f5d194569fa70d1c8735aca9829b1286fef32ba/botocore-1.43.83-py3-none-any.whl", hash = "sha256:bf75a6cf587c22d968e43e79fe122c39f82deafbe9c3422bc5d3e80b6210fc98", size = 15704489, upload-time = "2026-08-28T19:35:40.603Z" },
+]
+
+[[package]]
 name = "bracex"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1347,6 +1375,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -1561,6 +1598,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/9d/d56f68ec9a2c8aba3b7639e5d7a502d82cbf71c31e178a06c0955d789792/langchain_anthropic-1.5.4.tar.gz", hash = "sha256:113cb9bdac3169f2da65ea395dedb290e30dc6f899d01c205ba88aa88a2a02c2", size = 718860, upload-time = "2026-08-05T19:03:16.848Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/d8/47fb549e91f55a54ce829b5034a21360d9383342a3bf4986188e254e89e4/langchain_anthropic-1.5.4-py3-none-any.whl", hash = "sha256:730a9cb1ad384c9f1642840469c1ebbf20237066b1635f5d4fa9876e365fceaf", size = 56025, upload-time = "2026-08-05T19:03:15.579Z" },
+]
+
+[[package]]
+name = "langchain-aws"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "langchain-core" },
+    { name = "numpy" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/eb/0443568d23be1857df8f549c69acab0adab614adf91b5f13e5a3d796637f/langchain_aws-1.7.3.tar.gz", hash = "sha256:f2b148d5838aab04924574be20e17b2ef0568520861a11fe61b948fc7b143ca2", size = 671076, upload-time = "2026-08-20T18:55:17.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/7a/643cd85155e736f3dc2c363bb2b84630cffaec7e1944d46dd09b729d642e/langchain_aws-1.7.3-py3-none-any.whl", hash = "sha256:5e4f3dcc0bb4071bc9dfb556fc274fbf874516f198068d0a34bfbe937ea7e5e1", size = 231695, upload-time = "2026-08-20T18:55:15.698Z" },
 ]
 
 [[package]]
@@ -1936,6 +1988,17 @@ dependencies = [
     { name = "tavily-python" },
 ]
 
+[package.optional-dependencies]
+azure = [
+    { name = "langchain-openai" },
+]
+bedrock = [
+    { name = "langchain-aws" },
+]
+google = [
+    { name = "langchain-google-genai" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "ruff" },
@@ -1947,11 +2010,14 @@ requires-dist = [
     { name = "deepagents-code" },
     { name = "langchain", specifier = ">=1.0.0,<2.0" },
     { name = "langchain-anthropic" },
+    { name = "langchain-aws", marker = "extra == 'bedrock'" },
     { name = "langchain-community", specifier = ">=0.4.2" },
     { name = "langchain-core", specifier = ">=1.3.3,<2.0" },
+    { name = "langchain-google-genai", marker = "extra == 'google'" },
     { name = "langchain-mcp-adapters" },
     { name = "langchain-ollama", specifier = ">=1.1.0" },
     { name = "langchain-openai" },
+    { name = "langchain-openai", marker = "extra == 'azure'" },
     { name = "langchain-quickjs" },
     { name = "langgraph", specifier = ">=1.0.0,<2.0" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.0" },
@@ -1963,6 +2029,7 @@ requires-dist = [
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "tavily-python" },
 ]
+provides-extras = ["azure", "bedrock", "google"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "ruff", specifier = ">=0.15.17" }]
@@ -3459,6 +3526,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
     { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
     { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #10

## Problem

`python/models.py` instructs students to install a provider extra before swapping model providers:

```
Provider              Install command              Already installed?
--------------------  ---------------------------  ---------------------
Azure OpenAI          uv sync --extra azure        no - install first
AWS Bedrock           uv sync --extra bedrock      no - install first
Google Vertex/Gemini  uv sync --extra google       no - install first
```

However, `python/pyproject.toml` never defines a `[project.optional-dependencies]` table, so every documented command fails:

```
> uv sync --extra azure
Resolved 164 packages in 1ms
error: Extra `azure` is not defined in the project's `optional-dependencies` table
```

## Fix

Adds the three extras referenced by the docstring:

- `bedrock` → `langchain-aws` (provides `ChatBedrockConverse` used in the Bedrock example)
- `google` → `langchain-google-genai` (provides the `google_genai:` provider used in the Gemini example)
- `azure` → `langchain-openai` — `AzureChatOpenAI` already ships with the core `langchain-openai` dependency, so this extra resolves instantly; defining it keeps the documented command valid rather than erroring

`uv.lock` regenerated via `uv lock`. The lock diff is purely additive (langchain-aws 1.7.3 + boto3/botocore/s3transfer/jmespath, langchain-google-genai 4.3.2 + its deps); no existing pins changed.

## Verification

Each documented command run standalone from a clean checkout:

```
$ uv sync --extra azure
$ uv run python -c "from langchain_openai import AzureChatOpenAI; print('azure OK')"
azure OK

$ uv sync --extra bedrock
$ uv run python -c "from langchain_aws import ChatBedrockConverse; print('bedrock OK')"
bedrock OK

$ uv sync --extra google
$ uv run python -c "from langchain_google_genai import ChatGoogleGenerativeAI; print('google OK')"
google OK
```

The Azure example from `models.py` also constructs cleanly:

```
$ uv run python -c "from langchain_openai import AzureChatOpenAI; AzureChatOpenAI(azure_deployment='gpt-4.1', api_version='2024-12-01-preview')"
```

Based on `main` @ 54215a9.
